### PR TITLE
Stream support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gulpplugin"
   ],
   "dependencies": {
+    "bufferstreams": "^0.0.2",
     "convert-source-map": "^0.4.1",
     "es3-safe-recast": "^1.0.0",
     "esprima": "^1.2.2",
@@ -31,6 +32,8 @@
     "vinyl-sourcemaps-apply": "^0.1.3"
   },
   "devDependencies": {
-    "mocha": "^1.21.4"
+    "event-stream": "^3.1.7",
+    "mocha": "^1.21.4",
+    "string-to-stream": "^1.0.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,8 @@
 
 var assert = require('assert');
 var gutil = require('gulp-util');
+var es = require('event-stream');
+var stringToStream = require('string-to-stream');
 var dereserve = require('../');
 
 describe('dereserve', function() {
@@ -19,6 +21,27 @@ describe('dereserve', function() {
       base: __dirname,
       path: __dirname + '/file.js',
       contents: new Buffer('a.catch()')
+  }));
+
+  stream.end();
+  });
+
+  it('should work with stream.', function(cb) {
+  var stream = dereserve();
+
+  stream.on('data', function(file) {
+      assert.equal(file.relative, 'file.js');
+      file.contents.pipe(es.wait(function(err, data) {
+          assert(!err);
+          assert.equal(data, 'a["catch"]()');
+          cb();
+      }));
+  });
+
+  stream.write(new gutil.File({
+      base: __dirname,
+      path: __dirname + '/file.js',
+      contents: stringToStream('a.catch()')
   }));
 
   stream.end();


### PR DESCRIPTION
Now works with browserify bundle stream :smiley: 

``` javascript
var dereserve = require('gulp-dereserve');
var derequire = require('gulp-derequire');
var browserify = require('browserify');
var source = require('vinyl-source-stream');

gulp.task('build', function() {
    var bundleStream = browserify({entries: './index.js', standalone: 'yourModule'}).bundle();
    return bundleStream
        .pipe(source('yourModule.js'))
        .pipe(dereserve())
        .pipe(derequire())
        .pipe(gulp.dest('./build'));
});
```
