### PR TITLE
Update es3-safe-recast

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function transform(file, source) {
   }
 
   var ast = recast.parse(source, opt);
-  new es3safe.Visitor().visit(ast);
+  es3safe.visit(ast);
   var result = recast.print(ast, opt);
 
   if (inMap) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "bufferstreams": "^0.0.2",
     "convert-source-map": "^0.4.1",
-    "es3-safe-recast": "^1.0.0",
+    "es3-safe-recast": "^2.0.1",
     "esprima": "^1.2.2",
     "gulp-util": "^3.0.1",
     "recast": "^0.9.5",


### PR DESCRIPTION
There's a problem (stefanpenner/es3-safe-recast#16) with es3-safe-recast v. 1.0.0 that prevents gulp-dereserve from installing. I've bumped the version and updated the code to make the tests pass.